### PR TITLE
Fixed wrong createtable statement, now() instead datestring

### DIFF
--- a/maintain.class.php
+++ b/maintain.class.php
@@ -19,7 +19,7 @@ class Comments_on_Albums_maintain extends PluginMaintain
 CREATE TABLE IF NOT EXISTS `' . $this->table . '` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `category_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
-  `date` datetime NOT NULL DEFAULT "0000-00-00 00:00:00",
+  `date` datetime NOT NULL DEFAULT now(),
   `author` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `author_id` smallint(5) DEFAULT NULL,


### PR DESCRIPTION
On MySQL 5.7 the create statement was causing a database error. Using now() instead the datetime string solves this.