### PR TITLE
Uncaught mysqli_sql_exception: Invalid default value for 'date

### DIFF
--- a/maintain.class.php
+++ b/maintain.class.php
@@ -19,7 +19,7 @@ class Comments_on_Albums_maintain extends PluginMaintain
 CREATE TABLE IF NOT EXISTS `' . $this->table . '` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `category_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
-  `date` datetime NOT NULL DEFAULT now(),
+  `date` timestamp NOT NULL DEFAULT current_timestamp(),
   `author` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `author_id` smallint(5) DEFAULT NULL,


### PR DESCRIPTION
Gives error (and is not installable) with php 8.2.x and MySQL >= 5.5.68